### PR TITLE
Add TG Marker Cleaner dylib, build script, and README for TrollStore injection

### DIFF
--- a/README_TrollStore_Dylib.md
+++ b/README_TrollStore_Dylib.md
@@ -1,0 +1,26 @@
+# TG Marker Cleaner dylib（TrollStore 注入）
+
+本仓库提供 `substrate_replace_tg_marked.xm`，会将命中以下内容的字符串替换为单个空格：
+
+- `TG@macked_chat`
+- `TG@macked_channel`
+
+## 编译为可注入 `.dylib`
+
+```bash
+./build_trollstore_dylib.sh /path/to/iPhoneOS.sdk
+```
+
+产物路径：
+
+- `build/libTGMarkerCleaner.dylib`
+
+> 脚本默认编译 `arm64`、最低 iOS 14.0，并链接 Foundation。
+
+## 签名（示例）
+
+```bash
+ldid -S build/libTGMarkerCleaner.dylib
+```
+
+签名后即可用于支持 TrollStore 的注入工具流程。

--- a/build_trollstore_dylib.sh
+++ b/build_trollstore_dylib.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 用法:
+#   ./build_trollstore_dylib.sh /path/to/iPhoneOS.sdk
+# 产物:
+#   ./build/libTGMarkerCleaner.dylib
+
+SDK_PATH="${1:-}"
+if [[ -z "$SDK_PATH" ]]; then
+  echo "Usage: $0 /path/to/iPhoneOS.sdk"
+  exit 1
+fi
+
+if [[ ! -d "$SDK_PATH" ]]; then
+  echo "SDK not found: $SDK_PATH"
+  exit 1
+fi
+
+OUT_DIR="$(pwd)/build"
+mkdir -p "$OUT_DIR"
+
+SRC="$(pwd)/substrate_replace_tg_marked.xm"
+OUT="$OUT_DIR/libTGMarkerCleaner.dylib"
+
+clang++ -fobjc-arc -ObjC++ \
+  -dynamiclib \
+  -isysroot "$SDK_PATH" \
+  -arch arm64 \
+  -miphoneos-version-min=14.0 \
+  -framework Foundation \
+  -Wl,-undefined,dynamic_lookup \
+  "$SRC" \
+  -o "$OUT"
+
+echo "Built: $OUT"
+echo "Next: sign with ldid for TrollStore injection, e.g.:"
+echo "  ldid -S $OUT"

--- a/substrate_replace_tg_marked.xm
+++ b/substrate_replace_tg_marked.xm
@@ -1,0 +1,46 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+// 兼容无 substrate.h 头文件场景
+extern "C" void MSHookMessageEx(Class _class, SEL message, IMP hook, IMP *old);
+
+// 将命中的文本整体替换为一个空格
+static NSString *ReplaceIfNeeded(NSString *input) {
+    if (![input isKindOfClass:[NSString class]] || input.length == 0) {
+        return input;
+    }
+
+    if ([input containsString:@"TG@macked_chat"] ||
+        [input containsString:@"TG@macked_channel"]) {
+        return @" ";
+    }
+
+    return input;
+}
+
+static NSString *(*orig_NSString_stringWithString)(Class cls, SEL _cmd, NSString *str);
+static NSString *hook_NSString_stringWithString(Class cls, SEL _cmd, NSString *str) {
+    return orig_NSString_stringWithString(cls, _cmd, ReplaceIfNeeded(str));
+}
+
+static id (*orig_NSString_initWithString)(id self, SEL _cmd, NSString *str);
+static id hook_NSString_initWithString(id self, SEL _cmd, NSString *str) {
+    return orig_NSString_initWithString(self, _cmd, ReplaceIfNeeded(str));
+}
+
+__attribute__((constructor))
+static void init_tweak(void) {
+    @autoreleasepool {
+        Class nsStringCls = objc_getClass("NSString");
+
+        MSHookMessageEx(object_getClass(nsStringCls),
+                        @selector(stringWithString:),
+                        (IMP)hook_NSString_stringWithString,
+                        (IMP *)&orig_NSString_stringWithString);
+
+        MSHookMessageEx(nsStringCls,
+                        @selector(initWithString:),
+                        (IMP)hook_NSString_initWithString,
+                        (IMP *)&orig_NSString_initWithString);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small substrate tweak that removes Telegram marker strings by replacing them with a single space for processes injected via TrollStore. 
- Supply a reproducible build flow and documentation to produce a `.dylib` suitable for TrollStore injection.

### Description
- Add `substrate_replace_tg_marked.xm` which hooks `NSString` methods `stringWithString:` and `initWithString:` using `MSHookMessageEx` and replaces inputs containing `TG@macked_chat` or `TG@macked_channel` with a single space. 
- Add `build_trollstore_dylib.sh` which compiles the tweak into `build/libTGMarkerCleaner.dylib` using `clang++` for `arm64` with `-miphoneos-version-min=14.0` and links Foundation. 
- Add `README_TrollStore_Dylib.md` documenting build and signing steps and the produced artifact, including example `ldid -S` signing command. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f788b73934832aa8b7d3864c30c258)